### PR TITLE
Change DonateAction to extend TransferAction (instead of TradeAction)

### DIFF
--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -986,7 +986,7 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
 :DonateAction a rdfs:Class ;
     rdfs:label "DonateAction" ;
     rdfs:comment "The act of providing goods, services, or money without compensation, often for philanthropic reasons." ;
-    rdfs:subClassOf :TradeAction .
+    rdfs:subClassOf :TransferAction .
 
 :DownloadAction a rdfs:Class ;
     rdfs:label "DownloadAction" ;

--- a/data/schema.ttl
+++ b/data/schema.ttl
@@ -7755,7 +7755,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :price a rdf:Property ;
     rdfs:label "price" ;
-    :domainIncludes :Offer,
+    :domainIncludes :DonateAction,
+        :Offer,
         :PriceSpecification,
         :TradeAction ;
     :rangeIncludes :Number,
@@ -7772,7 +7773,8 @@ Note: for historical reasons, any textual label and formal code provided as a li
 
 :priceCurrency a rdf:Property ;
     rdfs:label "priceCurrency" ;
-    :domainIncludes :Offer,
+    :domainIncludes :DonateAction,
+        :Offer,
         :PriceSpecification,
         :Reservation,
         :Ticket,
@@ -7789,6 +7791,7 @@ Note: for historical reasons, any textual label and formal code provided as a li
 :priceSpecification a rdf:Property ;
     rdfs:label "priceSpecification" ;
     :domainIncludes :Demand,
+        :DonateAction,
         :Offer,
         :TradeAction ;
     :rangeIncludes :PriceSpecification ;


### PR DESCRIPTION
All the other TradeActions involve a swap of items or an intention of each party both giving something and receiving something in return. (In fact, in broader contexts, there's a phrase that "trade is the origin of most problems", and the concept is distinguished from gifts and donations.) TipAction is another possible difference, but it is done in return for good service... I could see an argument for it either way.

DonateAction seems distinctly different, explicitly "without compensation", so I propose to make it a subclass of TransferAction instead.